### PR TITLE
Improve account status validation

### DIFF
--- a/account-domain/src/main/java/code/exampleaxon/accountdomain/web/vo/AccountStatus.java
+++ b/account-domain/src/main/java/code/exampleaxon/accountdomain/web/vo/AccountStatus.java
@@ -21,6 +21,8 @@ public class AccountStatus {
     private static boolean isValidChange(String currentStatus, String nextStatus) {
         return currentStatus != null
                 && nextStatus != null
+                && accountLifeCycle.contains(currentStatus)
+                && accountLifeCycle.contains(nextStatus)
                 && accountLifeCycle.indexOf(currentStatus) < accountLifeCycle.indexOf(nextStatus);
     }
 

--- a/account-domain/src/test/java/code/exampleaxon/accountdomain/web/vo/AccountStatusTest.java
+++ b/account-domain/src/test/java/code/exampleaxon/accountdomain/web/vo/AccountStatusTest.java
@@ -1,0 +1,16 @@
+package code.exampleaxon.accountdomain.web.vo;
+
+import code.exampleaxon.accountdomain.exception.AccountStateChangeNotValidException;
+import org.junit.Test;
+
+public class AccountStatusTest {
+    @Test(expected = AccountStateChangeNotValidException.class)
+    public void invalidCurrentStatusShouldThrow() {
+        AccountStatus.validateAccountStateChange("id", "BAD", AccountStatus.ACCOUNT_STATUS_OPEN);
+    }
+
+    @Test(expected = AccountStateChangeNotValidException.class)
+    public void invalidNextStatusShouldThrow() {
+        AccountStatus.validateAccountStateChange("id", AccountStatus.ACCOUNT_STATUS_OPEN, "BAD");
+    }
+}


### PR DESCRIPTION
## Summary
- verify status is part of lifecycle before changing state
- add tests for invalid status changes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6843cdc64844832884ed4cea375f68d5