### PR TITLE
Update comment to mention H2

### DIFF
--- a/account-domain/src/main/resources/application.yml
+++ b/account-domain/src/main/resources/application.yml
@@ -1,5 +1,5 @@
-# To configure mysql on Ubuntu 18.04
-# https://www.digitalocean.com/community/tutorials/how-to-install-mysql-on-ubuntu-18-04
+# Example configuration using an embedded H2 database
+# https://www.h2database.com/html/main.html
 server:
   port: 8800
 logging.level:


### PR DESCRIPTION
## Summary
- update the comment in `application.yml` to reflect use of H2 instead of MySQL

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6843d29b14908328ad63f41324988b44