### PR TITLE
Add tests for invalid account state transitions

### DIFF
--- a/account-domain/src/test/java/code/exampleaxon/accountdomain/web/vo/AccountStatusTransitionTest.java
+++ b/account-domain/src/test/java/code/exampleaxon/accountdomain/web/vo/AccountStatusTransitionTest.java
@@ -1,0 +1,22 @@
+package code.exampleaxon.accountdomain.web.vo;
+
+import code.exampleaxon.accountdomain.exception.AccountStateChangeNotValidException;
+import org.junit.Test;
+
+public class AccountStatusTransitionTest {
+
+    @Test(expected = AccountStateChangeNotValidException.class)
+    public void invalidCurrentStatusShouldThrow() {
+        AccountStatus.validateAccountStateChange("id", "INVALID", AccountStatus.ACCOUNT_STATUS_OPEN);
+    }
+
+    @Test(expected = AccountStateChangeNotValidException.class)
+    public void invalidNextStatusShouldThrow() {
+        AccountStatus.validateAccountStateChange("id", AccountStatus.ACCOUNT_STATUS_OPEN, "UNKNOWN");
+    }
+
+    @Test(expected = AccountStateChangeNotValidException.class)
+    public void backwardTransitionShouldThrow() {
+        AccountStatus.validateAccountStateChange("id", AccountStatus.ACCOUNT_STATUS_ACTIVE, AccountStatus.ACCOUNT_STATUS_OPEN);
+    }
+}


### PR DESCRIPTION
## Summary
- add `AccountStatusTransitionTest` covering invalid statuses and backward transitions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6843d357d78c8328919ae4b9f5445787